### PR TITLE
[Feature] adds an sms api to send sms to customers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+release: python manage.py migrate
+
+web: gunicorn Store.wsgi:application

--- a/order/views.py
+++ b/order/views.py
@@ -5,6 +5,7 @@ Orders view.
 This view makes an order.
 """
 import datetime
+import requests
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication
@@ -102,6 +103,30 @@ class OrdersView(APIView):
                 product_amount
             )
             print(receit)
+            # Sends an sms to the user
+            sand_box_url = "https://api.sandbox.africastalking.com"\
+                "/version1/messaging"
+            api_Key = 'c13ef31c13abd536ff5ad57179cfc72993a'\
+                '2ff445dedbbd20bf0b9eb878e565d'
+            # request header
+            headers = {
+                "apiKey": api_Key,
+                "Content-Type": "application/x-www-form-urlencoded"
+            }
+            # request body
+            body = {
+                "username": "sandbox",
+                "to": "+254727645367",
+                "message": receit
+            }
+            # sending the request, the sms to the user
+            res = requests.post(
+                sand_box_url,
+                headers=headers,
+                data=body
+            )
+            print(res.text)
+            # returns api response
             return Response(serializer.data, status=201)
 
         # Returns an error if one the request data is invalid


### PR DESCRIPTION
## Description
A feature to send SMS to customers on the list of products they have purchased and the total price of the individual product, and the total cost of all items.

## SMS receiver
Sandbox simulator configured with a specified number to receive the SMS

## Screen shots
![image](https://user-images.githubusercontent.com/39832798/108000588-56e11c80-6ffb-11eb-884b-e255271de610.png)
![image](https://user-images.githubusercontent.com/39832798/108000609-70826400-6ffb-11eb-8379-c60932b43d40.png)
